### PR TITLE
Change login email textfield to use email keyboard to allow speech-to-text dictation

### DIFF
--- a/F1A-TV/Base.lproj/Main.storyboard
+++ b/F1A-TV/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="18122" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zrc-Yr-C9P">
     <device id="appleTV" appearance="dark"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18092"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -47,7 +47,7 @@
                                             <constraint firstAttribute="height" constant="70" id="4TD-Ph-R2f"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="38"/>
-                                        <textInputTraits key="textInputTraits" textContentType="email"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress" textContentType="email"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hMY-7T-DiR">
                                         <rect key="frame" x="0.0" y="634" width="1248" height="48"/>


### PR DESCRIPTION
Small change here that changes the keyboard type of the login email textfield to use the Email Address keyboard. In addition to being optimized for email addresses, this also lets you speak your email address to Siri and she'll type it in.

Before speaking out "k@email.com" would output "k at email dot com"

Now it will write out the email properly.

See the screenshots here where Siri hints as well: "Speak in full words" vs "speak in letters"

<img width="1571" alt="Screen Shot 2021-05-02 at 10 23 51" src="https://user-images.githubusercontent.com/15757117/116820210-03c63280-ab31-11eb-811e-fdadc45ab3b5.png">
<img width="1266" alt="Screen Shot 2021-05-02 at 10 25 05" src="https://user-images.githubusercontent.com/15757117/116820211-06288c80-ab31-11eb-8ebe-f9d17513b80a.png">

