### PR TITLE
Fix Ambiguous Audio Track Selection

### DIFF
--- a/F1A-TV/Controller/Views/Player/ControlStripOverlayViewController.swift
+++ b/F1A-TV/Controller/Views/Player/ControlStripOverlayViewController.swift
@@ -317,11 +317,11 @@ class ControlStripOverlayViewController: BaseViewController {
     func showLanguageSelectMenu() {
         let alertController = UIAlertController(title: NSLocalizedString("select", comment: ""), message: nil, preferredStyle: .alert)
         
-        for language in self.playerItem?.playerItem?.tracks(type: .audio) ?? [String]() {
-            alertController.addAction(UIAlertAction(title: language, style: .default, handler: { (UIAlertAction) in
-                let _ = self.playerItem?.playerItem?.select(type: .audio, name: language)
+        for language in self.playerItem?.playerItem?.tracks(type: .audio) ?? [MediaTrackDto]() {
+            alertController.addAction(UIAlertAction(title: language.displayName, style: .default, handler: { (UIAlertAction) in
+                let _ = self.playerItem?.playerItem?.select(type: .audio, item: language)
                 var playerSettings = CredentialHelper.getPlayerSettings()
-                playerSettings.setPreferredLanugage(for: self.playerItem?.contentItem.container.metadata?.channelType ?? ChannelType(), language: language)
+                playerSettings.setPreferredLanugage(for: self.playerItem?.contentItem.container.metadata?.channelType ?? ChannelType(), language: language.displayName)
                 CredentialHelper.setPlayerSettings(playerSettings: playerSettings)
             }))
         }
@@ -343,11 +343,11 @@ class ControlStripOverlayViewController: BaseViewController {
     func showCaptionSelectMenu() {
         let alertController = UIAlertController(title: NSLocalizedString("select", comment: ""), message: nil, preferredStyle: .alert)
         
-        for captions in self.playerItem?.playerItem?.tracks(type: .subtitle) ?? [String]() {
-            alertController.addAction(UIAlertAction(title: captions, style: .default, handler: { (UIAlertAction) in
-                let _ = self.playerItem?.playerItem?.select(type: .subtitle, name: captions)
+        for captions in self.playerItem?.playerItem?.tracks(type: .subtitle) ?? [MediaTrackDto]() {
+            alertController.addAction(UIAlertAction(title: captions.displayName, style: .default, handler: { (UIAlertAction) in
+                let _ = self.playerItem?.playerItem?.select(type: .subtitle, item: captions)
                 var playerSettings = CredentialHelper.getPlayerSettings()
-                playerSettings.setPreferredCaptions(for: self.playerItem?.contentItem.container.metadata?.channelType ?? ChannelType(), captions: captions)
+                playerSettings.setPreferredCaptions(for: self.playerItem?.contentItem.container.metadata?.channelType ?? ChannelType(), captions: captions.displayName)
                 CredentialHelper.setPlayerSettings(playerSettings: playerSettings)
             }))
         }

--- a/F1A-TV/Controller/Views/Player/PlayerCollectionViewController.swift
+++ b/F1A-TV/Controller/Views/Player/PlayerCollectionViewController.swift
@@ -257,12 +257,12 @@ class PlayerCollectionViewController: BaseCollectionViewController, UICollection
         let channelType = playerItem.contentItem.container.metadata?.channelType ?? ChannelType()
         
         if let preferredLanguage = playerSettings.getPreferredLanguage(for: channelType) {
-            let setLanguageResult = playerItem.playerItem?.select(type: .audio, name: preferredLanguage)
+            let setLanguageResult = playerItem.playerItem?.select(type: .audio, languageDisplayName: preferredLanguage)
             print("Setting preferred language: " + String(setLanguageResult ?? false))
         }
-        
+
         if let preferredCaptions = playerSettings.getPreferredCaptions(for: channelType) {
-            let setCaptionResult = playerItem.playerItem?.select(type: .subtitle, name: preferredCaptions)
+            let setCaptionResult = playerItem.playerItem?.select(type: .subtitle, languageDisplayName: preferredCaptions)
             print("Setting preferred caption: " + String(setCaptionResult ?? false))
         }
         

--- a/F1A-TV/Extensions/AVPlayerItemExtension.swift
+++ b/F1A-TV/Extensions/AVPlayerItemExtension.swift
@@ -6,6 +6,12 @@
 //
 
 import AVFoundation
+
+struct MediaTrackDto {
+    let displayName: String
+    let propertyList: Any
+}
+
 extension AVPlayerItem {
     enum TrackType {
         case subtitle
@@ -22,26 +28,43 @@ extension AVPlayerItem {
         }
     }
     
-    func tracks(type:TrackType) -> [String] {
+    func tracks(type:TrackType) -> [MediaTrackDto] {
         if let characteristic = type.characteristic(item: self) {
-            return characteristic.options.map { $0.displayName }
+            return characteristic.options.map {
+                MediaTrackDto(displayName: $0.displayName, propertyList: $0.propertyList())
+            }
         }
-        return [String]()
+        
+        return [MediaTrackDto]()
     }
     
-    func selected(type:TrackType) -> String? {
+    func selected(type:TrackType) -> MediaTrackDto? {
         guard let group = type.characteristic(item: self) else {
             return nil
         }
-        let selected = self.currentMediaSelection.selectedMediaOption(in: group)
-        return selected?.displayName
+        
+        guard let selected = self.currentMediaSelection.selectedMediaOption(in: group) else {
+            return nil
+        }
+        
+        return MediaTrackDto(displayName: selected.displayName, propertyList: selected.propertyList())
     }
     
-    func select(type:TrackType, name:String) -> Bool {
+    func select(type:TrackType, item: MediaTrackDto) -> Bool {
         guard let group = type.characteristic(item: self) else {
             return false
         }
-        guard let matched = group.options.filter({ $0.displayName == name }).first else {
+        
+        let option = group.mediaSelectionOption(withPropertyList: item.propertyList);
+        self.select(option, in: group)
+        return true
+    }
+    
+    func select(type:TrackType, languageDisplayName: String) -> Bool {
+        guard let group = type.characteristic(item: self) else {
+            return false
+        }
+        guard let matched = group.options.filter({ $0.displayName == languageDisplayName }).first else {
             return false
         }
         self.select(matched, in: group)


### PR DESCRIPTION
This addresses #38 where there are multiple audio tracks with the title "English”, and when trying to select different ones, there is no change in the audio track that is selected.

### Cause
The issue is a byproduct of how F1TV declares the various audio tracks in the `m3u8`, the available metadata from AVFoundation, and the way in which the app currently selects which media track.

“Good” `m3u8` example (user info redacted):
```other
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="English",DEFAULT=YES,AUTOSELECT=YES,LANGUAGE="eng",URI=".../OTT_F1_WIF_AUDIO_1_64000_eng_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="Deutsch",AUTOSELECT=YES,LANGUAGE="deu",URI=".../OTT_F1_WIF_AUDIO_2_64000_ger_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="Francais",AUTOSELECT=YES,LANGUAGE="fra",URI=".../OTT_F1_WIF_AUDIO_3_64000_fre_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="Espanol",AUTOSELECT=YES,LANGUAGE="spa",URI=".../OTT_F1_WIF_AUDIO_4_64000_spa_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="FX",AUTOSELECT=YES,LANGUAGE="cfx",URI=".../OTT_F1_WIF_AUDIO_0_64000_eng_vod.m3u8"
```

“Bad” m3u8 example (user info redacted):
```other
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="FX",DEFAULT=YES,AUTOSELECT=YES,LANGUAGE="eng",URI=".../OTT_F1_WIF_AUDIO_0_64000_eng_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="English",AUTOSELECT=YES,LANGUAGE="eng",URI=".../OTT_F1_WIF_AUDIO_1_64000_eng_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="German",AUTOSELECT=YES,LANGUAGE="ger",URI=".../OTT_F1_WIF_AUDIO_2_64000_ger_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="French",AUTOSELECT=YES,LANGUAGE="fre",URI=".../OTT_F1_WIF_AUDIO_3_64000_fre_vod.m3u8"
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="Encoding_0",NAME="Spanish",AUTOSELECT=YES,LANGUAGE="spa",URI=".../OTT_F1_WIF_AUDIO_4_64000_spa_vod.m3u8"
```

If you look closely at the “FX” track, in the bad example it has a `LANGUAGE` of `eng`. It has a unique `Name`, so it should possible to disambiguate the audio streams. However, the properties surfaced by AVFoundation – specifically `displayName` – don't directly match to these. `displayName` is actually a localised (by the device) string derived from the `LANGUAGE` attribute. This means in the ‘bad' scenario, there are two items in the audio tracks with a `displayName` of "English”.

The logic used by the app to select the specific track is driven by searching for a matching `displayName` in the from the assets auto tracks (sourced via `availableMediaCharacteristicsWithMediaSelectionOptions`,`AVMediaSelectionGroup`, and `AVMediaSelectionOption`). But since there are multiple items with the *same* `displayName`, the search matches the first time, every time.

For more details on the display name behaviours, see [this post](https://developer.apple.com/forums/thread/650968) from Apple.

Of interest, if you spelunk through the objects returns by the APIs, you can actually see the `Name` attributes value in a private dictionary, who's key appears only in [WebKit source code](https://github.com/WebKit/WebKit/blob/main/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm#L123) for managing & implementing MSE.

### Fix

`AVMediaSelectionOption` has a [method](https://developer.apple.com/documentation/avfoundation/avmediaselectionoption/1386310-propertylist) that returns a property list that, per apple:

> … that’s sufficient to identify the option within its group.

When used with `AVMediaSelectionGroup.mediaSelectionGroup(withPropertyList😀`, and `AVPlayerItem.select(AVMediaSelectionOption?, in:)`, you can uniquely identify the items – even with the duplicate `displayName`.

With this in mind, the extensions in `AVPlayerItemExtension` are updated to return & consume a new type (`MediaTrackDto`) that holds a display name (displayed to the user), and the result of calling `AVMediaSelectionOption.propertyList`. Maintaining the same calling patterns, with the additional data, everything functions great 🎉.

Additionally `displayName` was used in persisting the preferred language setting when the audio / caption language was changed. Since I don't believe that the property list is reusable across different playlists, the existing mechanism using `displayName` was left in place.