### PR TITLE
Secure credential storage with Keychain and eliminate force unwraps

### DIFF
--- a/F1A-TV.xcodeproj/project.pbxproj
+++ b/F1A-TV.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		1B78A79E2586440A007CF57C /* PlayerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B78A79D2586440A007CF57C /* PlayerController.swift */; };
 		1B7CCA5B261E0AB600FB25C2 /* ControlStripOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7CCA5A261E0AB600FB25C2 /* ControlStripOverlayViewController.swift */; };
 		1B80954525457D3E00889DFE /* CredentialHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B80954425457D3E00889DFE /* CredentialHelper.swift */; };
+		CC00000226031200000F1ATV /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000126031200000F1ATV /* KeychainHelper.swift */; };
 		1B85210C25F7CCA800B3356B /* IsoCountries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B85210B25F7CCA800B3356B /* IsoCountries.swift */; };
 		1B85210E25F7CCC400B3356B /* IsoCountryCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B85210D25F7CCC400B3356B /* IsoCountryCodes.swift */; };
 		1B85211425F8C5EB00B3356B /* Formula1-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1B85211025F8C5EB00B3356B /* Formula1-Black.ttf */; };
@@ -232,6 +233,7 @@
 		1B78A79D2586440A007CF57C /* PlayerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerController.swift; sourceTree = "<group>"; };
 		1B7CCA5A261E0AB600FB25C2 /* ControlStripOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlStripOverlayViewController.swift; sourceTree = "<group>"; };
 		1B80954425457D3E00889DFE /* CredentialHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialHelper.swift; sourceTree = "<group>"; };
+		CC00000126031200000F1ATV /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		1B85210B25F7CCA800B3356B /* IsoCountries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsoCountries.swift; sourceTree = "<group>"; };
 		1B85210D25F7CCC400B3356B /* IsoCountryCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsoCountryCodes.swift; sourceTree = "<group>"; };
 		1B85211025F8C5EB00B3356B /* Formula1-Black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Formula1-Black.ttf"; sourceTree = "<group>"; };
@@ -680,6 +682,7 @@
 				1BB23D022544EB0A00D0CC71 /* Protocols */,
 				1BB29C0B25446DC000ECC074 /* ConstantsUtil.swift */,
 				1B80954425457D3E00889DFE /* CredentialHelper.swift */,
+				CC00000126031200000F1ATV /* KeychainHelper.swift */,
 				1BF95A3E25EFAE3300A7C7C6 /* UserInteractionHelper.swift */,
 			);
 			path = Util;
@@ -1116,6 +1119,7 @@
 				1B9F8B73261CE6420020AC55 /* BaseTableViewCell.swift in Sources */,
 				1BE2B06628535F52007A1A2E /* DeviceRegistrationSessionSummaryDto.swift in Sources */,
 				1B80954525457D3E00889DFE /* CredentialHelper.swift in Sources */,
+				CC00000226031200000F1ATV /* KeychainHelper.swift in Sources */,
 				1B4F98D9261C85CE008FCE4A /* PlayerInfoOverlayViewController.swift in Sources */,
 				1BB29C0C25446DC000ECC074 /* ConstantsUtil.swift in Sources */,
 				1BB23CF42544E3C800D0CC71 /* DateExtension.swift in Sources */,

--- a/F1A-TV/Controller/Views/Security/AccountOverviewViewController.swift
+++ b/F1A-TV/Controller/Views/Security/AccountOverviewViewController.swift
@@ -78,7 +78,7 @@ class AccountOverviewViewController: BaseViewController, DeviceRegistrationLoade
     }
     
     func didPerformDeviceUnregistration() {
-        CredentialHelper.instance.setDeviceRegistration(deviceRegistration: DeviceRegistrationResultDto())
+        CredentialHelper.instance.clearCredentials()
         self.setupView()
     }
 }

--- a/F1A-TV/Util/ConstantsUtil.swift
+++ b/F1A-TV/Util/ConstantsUtil.swift
@@ -38,7 +38,11 @@ struct ConstantsUtil {
     static let playerSettingsKeyValueStorageKey = "F1ATV_PlayerSettingsKVSKey"
     static let deviceRegistrationKeyValueStorageKey = "F1ATV_DeviceRegistrationKVSKey"
 
-    
+    //KeychainKeys
+    static let keychainPasswordKey = "F1ATV_Password"
+    static let keychainDeviceRegistrationKey = "F1ATV_DeviceRegistration"
+
+
     //Controller
     static let accountOverviewViewController = "AccountOverviewViewController"
     static let loginViewController = "LoginViewController"

--- a/F1A-TV/Util/CredentialHelper.swift
+++ b/F1A-TV/Util/CredentialHelper.swift
@@ -7,118 +7,87 @@
 
 import Foundation
 
-class CredentialHelper: AuthDataLoadedProtocol {
+class CredentialHelper {
     static let instance = CredentialHelper()
-    
+
+    private init() {
+        migrateFromCoreDataIfNeeded()
+    }
+
     func isLoginInformationCached() -> Bool {
         return !self.getDeviceRegistration().sessionId.isEmpty
     }
-    
+
+    // MARK: - Password (Keychain)
+
     func setPassword(password: String) {
-        DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.passwordKeyValueStorageKey, value: password))
+        try? KeychainHelper.saveString(password, forKey: ConstantsUtil.keychainPasswordKey)
     }
-    
+
     func getPassword() -> String {
-        let object = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.passwordKeyValueStorageKey)
-        if(object.key != ConstantsUtil.passwordKeyValueStorageKey){
-            self.setPassword(password: "")
-            return self.getPassword()
-        }
-        return object.value
+        return KeychainHelper.readString(forKey: ConstantsUtil.keychainPasswordKey) ?? ""
     }
-    
+
+    // MARK: - Device Registration (Keychain)
+
     func getDeviceRegistration() -> DeviceRegistrationResultDto {
-        let object = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.deviceRegistrationKeyValueStorageKey)
-        if(object.key != ConstantsUtil.deviceRegistrationKeyValueStorageKey){
-            self.setDeviceRegistration(deviceRegistration: DeviceRegistrationResultDto())
-            return self.getDeviceRegistration()
-        }
-        let decoder = JSONDecoder()
-//        print(object.value)
-        do {
-            return try decoder.decode(DeviceRegistrationResultDto.self, from: object.value.data(using: .utf8)!)
-        }catch{
-            return DeviceRegistrationResultDto()
-        }
+        return KeychainHelper.readCodable(DeviceRegistrationResultDto.self, forKey: ConstantsUtil.keychainDeviceRegistrationKey) ?? DeviceRegistrationResultDto()
     }
-    
+
     func setDeviceRegistration(deviceRegistration: DeviceRegistrationResultDto) {
-        var dataString = ""
-        do{
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(deviceRegistration)
-            dataString = String(data: data, encoding: .utf8) ?? ""
-//            print(dataString)
-        }catch{
-            print("Encoding failed")
-            return
-        }
-        DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.deviceRegistrationKeyValueStorageKey, value: dataString))
+        try? KeychainHelper.saveCodable(deviceRegistration, forKey: ConstantsUtil.keychainDeviceRegistrationKey)
     }
-    
-    /*func getUserInfo() -> AuthResultDto {
-        let object = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.userInfoKeyValueStorageKey)
-        if(object.key != ConstantsUtil.userInfoKeyValueStorageKey){
-            self.setUserInfo(userInfo: AuthResultDto())
-            return self.getUserInfo()
-        }
-        let decoder = JSONDecoder()
-//        print(object.value)
-        do {
-            return try decoder.decode(AuthResultDto.self, from: object.value.data(using: .utf8)!)
-        }catch{
-            return AuthResultDto()
-        }
-    }
-    
-    func setUserInfo(userInfo: AuthResultDto) {
-        var dataString = ""
-        do{
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(userInfo)
-            dataString = String(data: data, encoding: .utf8) ?? ""
-//            print(dataString)
-        }catch{
-            print("Encoding failed")
-            return
-        }
-        DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.userInfoKeyValueStorageKey, value: dataString))
-    }*/
-    
+
+    // MARK: - Player Settings (CoreData — not sensitive)
+
     class func getPlayerSettings() -> PlayerSettings {
         let object = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.playerSettingsKeyValueStorageKey)
-        if(object.key != ConstantsUtil.playerSettingsKeyValueStorageKey){
+        if object.key != ConstantsUtil.playerSettingsKeyValueStorageKey {
             self.setPlayerSettings(playerSettings: PlayerSettings())
-            return self.getPlayerSettings()
+            return PlayerSettings()
         }
-        let decoder = JSONDecoder()
-//        print(object.value)
+        guard let data = object.value.data(using: .utf8) else {
+            return PlayerSettings()
+        }
         do {
-            return try decoder.decode(PlayerSettings.self, from: object.value.data(using: .utf8)!)
-        }catch{
+            return try JSONDecoder().decode(PlayerSettings.self, from: data)
+        } catch {
             return PlayerSettings()
         }
     }
-    
+
     class func setPlayerSettings(playerSettings: PlayerSettings) {
-        var dataString = ""
-        do{
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(playerSettings)
-            dataString = String(data: data, encoding: .utf8) ?? ""
-//            print(dataString)
-        }catch{
+        do {
+            let data = try JSONEncoder().encode(playerSettings)
+            let dataString = String(data: data, encoding: .utf8) ?? ""
+            DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.playerSettingsKeyValueStorageKey, value: dataString))
+        } catch {
             print("Encoding failed")
-            return
         }
-        DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.playerSettingsKeyValueStorageKey, value: dataString))
     }
-    
-    /*func performAuthRequest(authRequest: AuthRequestDto) {
-        DataManager.instance.loadAuthData(authRequest: authRequest, authDataLoadedProtocol: self)
-    }*/
-    
-    func didLoadAuthData(authResult: AuthResultDto) {
-        //CredentialHelper.instance.setUserInfo(userInfo: authResult)
+
+    // MARK: - Logout
+
+    func clearCredentials() {
+        try? KeychainHelper.deleteAll()
+    }
+
+    // MARK: - One-time migration from CoreData to Keychain
+
+    private func migrateFromCoreDataIfNeeded() {
+        let passwordObject = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.passwordKeyValueStorageKey)
+        if passwordObject.key == ConstantsUtil.passwordKeyValueStorageKey, !passwordObject.value.isEmpty {
+            try? KeychainHelper.saveString(passwordObject.value, forKey: ConstantsUtil.keychainPasswordKey)
+            DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.passwordKeyValueStorageKey, value: ""))
+        }
+
+        let regObject = DataSource.instance.getKeyValuePair(keyString: ConstantsUtil.deviceRegistrationKeyValueStorageKey)
+        if regObject.key == ConstantsUtil.deviceRegistrationKeyValueStorageKey, !regObject.value.isEmpty {
+            if let data = regObject.value.data(using: .utf8),
+               let registration = try? JSONDecoder().decode(DeviceRegistrationResultDto.self, from: data) {
+                try? KeychainHelper.saveCodable(registration, forKey: ConstantsUtil.keychainDeviceRegistrationKey)
+                DataSource.instance.addKeyValue(keyValuePair: KeyValueStoreObject(id: UUID().uuidString.lowercased(), key: ConstantsUtil.deviceRegistrationKeyValueStorageKey, value: ""))
+            }
+        }
     }
 }

--- a/F1A-TV/Util/KeychainHelper.swift
+++ b/F1A-TV/Util/KeychainHelper.swift
@@ -1,0 +1,103 @@
+//
+//  KeychainHelper.swift
+//  F1TV
+//
+//  Created by Rob Mulder on 12.03.26.
+//
+
+import Foundation
+import Security
+
+enum KeychainError: Error {
+    case saveFailed(OSStatus)
+    case deleteFailed(OSStatus)
+    case encodingFailed
+}
+
+struct KeychainHelper {
+    private static let service = "com.f1atv.credentials"
+
+    // MARK: - String operations
+
+    static func saveString(_ value: String, forKey key: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.encodingFailed
+        }
+        try saveData(data, forKey: key)
+    }
+
+    static func readString(forKey key: String) -> String? {
+        guard let data = readData(forKey: key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - Codable operations
+
+    static func saveCodable<T: Encodable>(_ value: T, forKey key: String) throws {
+        let data = try JSONEncoder().encode(value)
+        try saveData(data, forKey: key)
+    }
+
+    static func readCodable<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let data = readData(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    // MARK: - Delete operations
+
+    static func delete(forKey key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+
+    static func deleteAll() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+
+    // MARK: - Private
+
+    private static func saveData(_ data: Data, forKey key: String) throws {
+        // Delete existing item first
+        try? delete(forKey: key)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status)
+        }
+    }
+
+    private static func readData(forKey key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+}


### PR DESCRIPTION
## Summary

  - **Passwords and device registration moved from plain text CoreData to Keychain** with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` protection
  - **3 force unwraps eliminated** (`data(using: .utf8)!`) — replaced with safe `guard let` / nil-coalescing
  - **3 recursive patterns removed** (`setDefault() → getX()` loops that could stack overflow) — now return defaults directly
  - **~40 lines of dead code removed** (commented-out methods, empty `didLoadAuthData`, unused `AuthDataLoadedProtocol` conformance)
  - **`clearCredentials()` added** for proper logout cleanup
  - **One-time migration** ensures existing users keep their session after updating

  ## Changes

  | File | Action |
  |------|--------|
  | `F1A-TV/Util/KeychainHelper.swift` | New — compact Security framework wrapper |
  | `F1A-TV/Util/CredentialHelper.swift` | Rewrite (124 → 93 lines) |
  | `F1A-TV/Util/ConstantsUtil.swift` | 2 Keychain key constants added |
  | `F1A-TV/Controller/Views/Security/AccountOverviewViewController.swift` | Logout uses `clearCredentials()` |

  ## Backward compatibility

  The public API is unchanged — no caller modifications needed. PlayerSettings remain in CoreData (not sensitive).

  ## Test plan

  - [ ] Build succeeds on tvOS Simulator
  - [ ] Install old version → log in → update to new version → session is preserved (migration)
  - [ ] Logout clears all Keychain items
  - [ ] `grep -n '!' CredentialHelper.swift` shows zero force unwraps